### PR TITLE
feat(cve-2024-3094): not clean terminal screen

### DIFF
--- a/xz_cve-2024-3094-detect.sh
+++ b/xz_cve-2024-3094-detect.sh
@@ -17,8 +17,6 @@
 
 set -eu
 
-clear
-
 echo "Checking system for CVE-2024-3094 Vulnerability..."
 echo "https://nvd.nist.gov/vuln/detail/CVE-2024-3094"
 


### PR DESCRIPTION
May we maybe not clean the terminal screen on execution? This reminds me of [such ssh copy attacks](https://thejh.net/misc/website-terminal-copy-paste) etc and lets me freak out… (yeah of course I checked the script locally, but anyway…)

But TBH I just see no reason to clear the screen, it interferes and IMHO [also violates POLA](https://en.wikipedia.org/wiki/Principle_of_least_astonishment).